### PR TITLE
workflow_server.rst fix broken links

### DIFF
--- a/docs/pages/agws/workflow_server.rst
+++ b/docs/pages/agws/workflow_server.rst
@@ -1,11 +1,11 @@
 Agent Workflow Server
 =====================
 
-The `Agent Workflow Server <https://github.com/agntcy/workflow-srv>`_ enables participation in the Internet of Agents. It accommodates AI Agents from diverse frameworks and exposes them through Agent Connect Protocol (`ACP <../syntactic_sdk/agntcy_acp_sdk.html>`_), regardless of their underlying implementation.
+The `Agent Workflow Server <https://github.com/agntcy/workflow-srv>`_ enables participation in the Internet of Agents. It accommodates AI Agents from diverse frameworks and exposes them through Agent Connect Protocol (`ACP <https://github.com/agntcy/acp-sdk>`_), regardless of their underlying implementation.
 
 .. note::
 
-   If you wish to quickly deploy and run your Agent, please check out the user-facing `Workflow Server Manager <workflow_server_manager.html>`_ instead.
+   If you wish to quickly deploy and run your Agent, please check out the user-facing `Workflow Server Manager <https://github.com/agntcy/workflow-srv-mgr>`_ instead.
 
 Getting Started
 ---------------


### PR DESCRIPTION
Updated broken links to point to target repos: [workflow-srv-mgr](https://github.com/agntcy/workflow-srv-mgr) and [acp-sdk](https://github.com/agntcy/acp-sdk).