### PR TITLE
fix: add soft link to avoid broken external links

### DIFF
--- a/docs/pages/hub.md
+++ b/docs/pages/hub.md
@@ -1,0 +1,1 @@
+agent_directory.md


### PR DESCRIPTION
External links are still pointing to https://docs.agntcy.org/pages/hub.html , which is now responding with 404 as the page migrated.
This PR adds a soft link to allow  time for the external links to be migrated as well.