### PR TITLE
chore: add ctm script

### DIFF
--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
 
+{% block extrahead %}
+    <script type="text/javascript" src="//www.cisco.com/c/dam/cdc/t/ctm-core.js"></script>
+    {{ super() }}
+{% endblock %}
+
 {% block scripts %}
-  <!-- Parent theme scripts -->
-  {{ super() }}
-  
-  <!-- Cisco CTM (Cisco Tag Manager) script -->
-  <script type="text/javascript" src="//www.cisco.com/c/dam/cdc/t/ctm.js"></script>
+    {{ super() }}
+    <!-- Cisco CTM (Cisco Tag Manager) script -->
+    <script type="text/javascript" src="//www.cisco.com/c/dam/cdc/t/ctm.js"></script>
 {% endblock %}

--- a/mkdocs/overrides/main.html
+++ b/mkdocs/overrides/main.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block scripts %}
+  <!-- Parent theme scripts -->
+  {{ super() }}
+  
+  <!-- Cisco CTM (Cisco Tag Manager) script -->
+  <script type="text/javascript" src="//www.cisco.com/c/dam/cdc/t/ctm.js"></script>
+{% endblock %}


### PR DESCRIPTION
## Related to OneTrust Cookie Consent
Trying to add ctm script according to https://tags.cisco.com/tagging/onboarding
Referencing documentation here:  https://squidfunk.github.io/mkdocs-material/customization/#overriding-blocks