### PR TITLE
chore: added issue template for the docs repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,30 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: New Issue
+description: Submit a new issue to help us improve.
+title: "[Docs]: "
+labels: ["Documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to submiting this issue!
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: Please provide a description of the problem.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      description: By submitting this issue, you agree to the following
+      options:
+        - label: I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: I have verified this does not duplicate an existing issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -18,6 +18,29 @@ body:
       description: Please provide a description of the problem.
     validations:
       required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Prposed Solution
+      description: Please provide a description of how the problem can be solved.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: |
+        If applicable, provide the component relevant to this issue.
+      options:
+        - CSIT
+        - Directory
+        - Identity
+        - OASF
+        - SLIM
+        - Other
+      default: 0
+    validations:
+      required: false
   - type: checkboxes
     id: checklist
     attributes:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ site
 
 # Generated files
 generated/
+.DS_Store


### PR DESCRIPTION
Fixes #134 

Added a simple template when creating new issues.
The new template will prompt for:
- Title
- Issue description and solution
- Affected components
- Confirmation of: contributing guide and non-duplicate

![new-issue](https://github.com/user-attachments/assets/ac4c22e9-357a-4586-b9e8-249b4eacebb5)
