### PR TITLE
chore: adding notice to components that are not currently worked on

### DIFF
--- a/docs/agws/workflow-server-manager.md
+++ b/docs/agws/workflow-server-manager.md
@@ -1,5 +1,8 @@
 # Workflow Server Manager
 
+!!! info
+    This component is not currently under active development. While it remains available, updates and new features are not planned at this time.
+
 The Workflow Server Manager (WFSM) is a command line tool that streamlines the process of wrapping an agent into a container image, starting the container, and exposing the agent functionality through the Agent Connect Protocol (ACP).
 
 The WFSM tool takes an [Agent Manifest](../manifest/manifest.md) as input and based on it spins up a web server container exposing the agent through ACP through REST api.

--- a/docs/agws/workflow-server.md
+++ b/docs/agws/workflow-server.md
@@ -1,5 +1,8 @@
 # Agent Workflow Server
 
+!!! info
+    This component is not currently under active development. While it remains available, updates and new features are not planned at this time.
+
 The [Agent Workflow Server](https://github.com/agntcy/workflow-srv)
 enables participation in the Internet of Agents. It accommodates AI
 Agents from diverse frameworks and exposes them through Agent Connect

--- a/docs/manifest/manifest.md
+++ b/docs/manifest/manifest.md
@@ -1,5 +1,8 @@
 # Agent Manifest
 
+!!! info
+    This component is not currently under active development. While it remains available, updates and new features are not planned at this time.
+
 An Agent Manifest is a document that describes in detail the following:
 
 * What the agent is capable of.

--- a/docs/syntactic/agntcy_acp_sdk.md
+++ b/docs/syntactic/agntcy_acp_sdk.md
@@ -1,5 +1,8 @@
 # Agntcy ACP Client
 
+!!! info
+    This component is not currently under active development. While it remains available, updates and new features are not planned at this time.
+
 ## Introduction
 
 The Agent Connect Protocol SDK is an open-source library designed to

--- a/docs/syntactic/connect.md
+++ b/docs/syntactic/connect.md
@@ -1,5 +1,8 @@
 # Agent Connect Protocol
 
+!!! info
+    This component is not currently under active development. While it remains available, updates and new features are not planned at this time.
+
 ## Introduction
 
 Existing Multi-Agent Systems (MAS) provide convenient ways to build Multi-Agent Applications (MAAs) that combine various agents and enable them to communicate with each other. Such communication occurs within the MAS using internal mechanisms and APIs.


### PR DESCRIPTION
Added notice that the following components are not being actively developed:
* ACP
* Workflow Server
* Workflow Server Manager
* Agent Manifest