### PR TITLE
docs: update dir docs according to the extension to module change

### DIFF
--- a/docs/dir/dir-routing-v1-api.md
+++ b/docs/dir/dir-routing-v1-api.md
@@ -198,7 +198,7 @@ Defines a list of supported record query types.
 | RECORD_QUERY_TYPE_SKILL | 1 | Query for a skill name. |
 | RECORD_QUERY_TYPE_LOCATOR | 2 | Query for a locator type. |
 | RECORD_QUERY_TYPE_DOMAIN | 3 | Query for a domain name. |
-| RECORD_QUERY_TYPE_FEATURE | 4 | Query for a feature name. |
+| RECORD_QUERY_TYPE_MODULE | 4 | Query for a module name. |
 
 <a name="agntcy_dir_routing_v1_routing_service-proto"></a>
 <p align="right"><a href="#top">Top</a></p>

--- a/docs/dir/dir-search-v1-api.md
+++ b/docs/dir/dir-search-v1-api.md
@@ -50,7 +50,7 @@ Defines a list of supported record query types.
 | RECORD_QUERY_TYPE_SKILL_ID | 3 | Query for a skill ID. Numeric field - exact match only, no wildcard support. |
 | RECORD_QUERY_TYPE_SKILL_NAME | 4 | Query for a skill name. Supports wildcard patterns: &#34;python*&#34;, &#34;*script&#34;, &#34;*machine*learning*&#34;, &#34;Python?&#34;, &#34;[A-M]*&#34; |
 | RECORD_QUERY_TYPE_LOCATOR | 5 | Query for a locator type. Supports wildcard patterns: &#34;http*&#34;, &#34;ftp*&#34;, &#34;*docker*&#34;, &#34;[hf]tt[ps]*&#34; |
-| RECORD_QUERY_TYPE_EXTENSION | 6 | Query for an extension. Supports wildcard patterns: &#34;*-plugin&#34;, &#34;*-extension&#34;, &#34;core*&#34;, &#34;ext-?&#34;, &#34;plugin-[0-9]&#34; |
+| RECORD_QUERY_TYPE_MODULE | 6 | Query for a module. Supports wildcard patterns: &#34;*-plugin&#34;, &#34;*-module&#34;, &#34;core*&#34;, &#34;mod-?&#34;, &#34;plugin-[0-9]&#34; |
 
 <a name="agntcy_dir_search_v1_search_service-proto"></a>
 <p align="right"><a href="#top">Top</a></p>

--- a/docs/dir/directory-cli.md
+++ b/docs/dir/directory-cli.md
@@ -173,6 +173,8 @@ The following flags are available:
 
 - `--skill <skill>` - Filter by skill (repeatable)
 - `--locator <type>` - Filter by locator type (repeatable)
+- `--domain <domain>` - Filter by domain (repeatable)
+- `--module <module>` - Filter by module name (repeatable)
 - `--cid <cid>` - List specific record by CID
 - `--limit <number>` - Limit number of results
 
@@ -189,8 +191,12 @@ The following flags are available:
     # List by locator type
     dirctl routing list --locator "docker-image"
 
+    # List by module
+    dirctl routing list --module "runtime/framework"
+
     # Multiple criteria (AND logic)
     dirctl routing list --skill "AI" --locator "docker-image"
+    dirctl routing list --domain "healthcare" --module "runtime/language"
 
     # Specific record by CID
     dirctl routing list --cid baeareihdr6t7s6sr2q4zo456sza66eewqc7huzatyfgvoupaqyjw23ilvi
@@ -207,6 +213,8 @@ The following flags are available:
 
 - `--skill <skill>` - Search by skill (repeatable)
 - `--locator <type>` - Search by locator type (repeatable)
+- `--domain <domain>` - Search by domain (repeatable)
+- `--module <module>` - Search by module name (repeatable)
 - `--limit <number>` - Maximum results to return
 - `--min-score <score>` - Minimum match score threshold
 
@@ -229,8 +237,12 @@ The output includes the following:
     # Search by locator type
     dirctl routing search --locator "docker-image"
 
+    # Search by module
+    dirctl routing search --module "runtime/framework"
+
     # Advanced search with scoring
     dirctl routing search --skill "web-development" --limit 10 --min-score 1
+    dirctl routing search --domain "finance" --module "validation" --min-score 2
     ```
 
 **Output includes:**

--- a/docs/dir/hosted-agent-directory.md
+++ b/docs/dir/hosted-agent-directory.md
@@ -80,7 +80,7 @@ You can refine the results using predefined filters and open search:
 * Use the record type drop down menu to filter by agent or MCP server records.
 * Use the drop-down **Agent Skills** list to narrow the results by skill.
 * Use the drop-down **Locators** list to narrow the results by locator type.
-* Use the drop-down **Extensions** list to narrow the results by extension type.
+* Use the drop-down **Modules** list to narrow the results by module name.
 * Use the drop-down sort by list to sort the displayed items by most recent or oldest.
 
 ### Manage Records Associated with Your Organization
@@ -94,7 +94,7 @@ You can refine the results using predefined filters and open search:
 * Use the record type drop down menu to filter by agent or MCP server records.
 * Use the drop-down **Agent Skills** list to narrow the results by skill.
 * Use the drop-down **Locators** list to narrow the results by locator type.
-* Use the drop-down **Extensions** list to narrow the results by extension type.
+* Use the drop-down **Modules** list to narrow the results by module name.
 
 ![The My Directory Page](../assets/hosted-dir/directory.png)
 

--- a/docs/dir/scenarios.md
+++ b/docs/dir/scenarios.md
@@ -230,7 +230,7 @@ dirctl routing search --skill "images_computer_vision" \
                       --limit 5
 ```
 
-Network search supports hierarchical matching where skills, domains, and features use both
+Network search supports hierarchical matching where skills, domains, and modules use both
 exact and prefix matching (e.g., `images_computer_vision` matches both `images_computer_vision`
 and `images_computer_vision/image_segmentation` as a prefix).
 
@@ -264,8 +264,8 @@ dirctl search --query "skill-name=images_computer_vision/image_segmentation"
 # Search for records with a specific locator type and URL
 dirctl search --query "locator=docker_image:https://example.com/my-agent"
 
-# Search for records with a specific extension
-dirctl search --query "extension=my-custom-extension:v1.0.0"
+# Search for records with a specific module
+dirctl search --query "module=my-custom-module"
 
 # Combine multiple query filters (AND operation)
 dirctl search \
@@ -321,7 +321,7 @@ dirctl search --query "name=web-[0-9]?" --query "version=v?.*.?"
 - `skill-id` - Search by skill ID number
 - `skill-name` - Search by skill name
 - `locator` - Search by locator (format: `type:url`)
-- `extension` - Search by extension (format: `name:version`)
+- `module` - Search by module name
 
 **Query Format:**
 


### PR DESCRIPTION
Updated the routing commands documentation to include the missing --module and --domain flags for both dirctl routing list and dirctl routing search commands, with practical examples showing module-based filtering. Also corrected the hierarchical matching description to reference "modules" instead of the outdated "features" terminology, ensuring consistency with the versionless module implementation across all documentation.