### PR TITLE
feat: adding reuse capabilities through include-markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ site
 # Generated files
 generated/
 .DS_Store
+
+# Python cache
+__pycache__/
+*.pyc

--- a/mkdocs/hooks.py
+++ b/mkdocs/hooks.py
@@ -1,0 +1,17 @@
+"""MkDocs hooks to configure SSL certificates for include-markdown plugin."""
+import ssl
+import certifi
+
+# Monkey patch urllib to use certifi's certificate bundle
+def on_startup(**kwargs):
+    """Configure SSL context to use certifi certificates."""
+    import urllib.request
+    
+    # Create SSL context with certifi's certificate bundle
+    ssl_context = ssl.create_default_context(cafile=certifi.where())
+    
+    # Set the default opener to use this context
+    https_handler = urllib.request.HTTPSHandler(context=ssl_context)
+    opener = urllib.request.build_opener(https_handler)
+    urllib.request.install_opener(opener)
+

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -24,6 +24,9 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
 
+hooks:
+  - hooks.py
+
 plugins:
   search:
   awesome-pages:
@@ -73,6 +76,8 @@ plugins:
     raise_error: false
     raise_error_after_finish: false
     validate_external_urls: true
+  include-markdown:
+
 theme:
   name: material
   custom_dir: overrides

--- a/mkdocs/pyproject.toml
+++ b/mkdocs/pyproject.toml
@@ -22,8 +22,10 @@ dependencies = [
     "agntcy-iomapper==0.2.2",
     "beautifulsoup4>=4.13.3",
     "mkdocs-swagger-ui-tag==0.7.1",
+    "mkdocs-include-markdown-plugin>=7.2.0",
     # Linting and testing tools
     "codespell>=2.2.0",
     "pymarkdownlnt>=0.9.0",
     "mkdocs-htmlproofer-plugin>=1.0.0",
+    "certifi>=2025.1.31",
 ]

--- a/mkdocs/uv.lock
+++ b/mkdocs/uv.lock
@@ -40,6 +40,7 @@ dependencies = [
     { name = "agntcy-acp" },
     { name = "agntcy-iomapper" },
     { name = "beautifulsoup4" },
+    { name = "certifi" },
     { name = "codespell" },
     { name = "griffe" },
     { name = "griffe-pydantic" },
@@ -50,6 +51,7 @@ dependencies = [
     { name = "mkdocs-exclude" },
     { name = "mkdocs-git-revision-date-plugin" },
     { name = "mkdocs-htmlproofer-plugin" },
+    { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocs-material-extensions" },
     { name = "mkdocs-swagger-ui-tag" },
@@ -64,6 +66,7 @@ requires-dist = [
     { name = "agntcy-acp", specifier = "==1.1.2" },
     { name = "agntcy-iomapper", specifier = "==0.2.2" },
     { name = "beautifulsoup4", specifier = ">=4.13.3" },
+    { name = "certifi", specifier = ">=2025.1.31" },
     { name = "codespell", specifier = ">=2.2.0" },
     { name = "griffe", specifier = "==1.7.2" },
     { name = "griffe-pydantic", specifier = "==1.1.4" },
@@ -74,6 +77,7 @@ requires-dist = [
     { name = "mkdocs-exclude", specifier = "==1.0.2" },
     { name = "mkdocs-git-revision-date-plugin", specifier = "==0.3.2" },
     { name = "mkdocs-htmlproofer-plugin", specifier = ">=1.0.0" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.2.0" },
     { name = "mkdocs-material", specifier = "==9.6.12" },
     { name = "mkdocs-material-extensions", specifier = ">=1.0.3" },
     { name = "mkdocs-swagger-ui-tag", specifier = "==0.7.1" },
@@ -1864,6 +1868,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/97/ba794c328e6bf13bf8d0293e1b339d94ccaee92b402a2e67c3eb0122bb2e/mkdocs-htmlproofer-plugin-1.3.0.tar.gz", hash = "sha256:9d9c0830305593d5f3993f0355956bee557a7c0924d63c3caacf7924ed4f444f", size = 8804, upload-time = "2024-09-13T14:46:09.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/b1/04c7cd3c2dfb184e352ee60cfb0212644d55ac3dc82d927950f54017e692/mkdocs_htmlproofer_plugin-1.3.0-py3-none-any.whl", hash = "sha256:715e0648b60a92d2c838ca42deacc67c9c2a855486122cc328f573d27ceebc7c", size = 8920, upload-time = "2024-09-13T14:46:07.303Z" },
+]
+
+[[package]]
+name = "mkdocs-include-markdown-plugin"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/10/b0b75ac42f4613556a808eee2dad3efe7a7d5079349aa5b9229d863e829f/mkdocs_include_markdown_plugin-7.2.0.tar.gz", hash = "sha256:4a67a91ade680dc0e15f608e5b6343bec03372ffa112c40a4254c1bfb10f42f3", size = 25509, upload-time = "2025-09-28T21:50:50.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/f9/783338d1d7fd548c7635728b67a0f8f96d9e6c265aa61c51356c03597767/mkdocs_include_markdown_plugin-7.2.0-py3-none-any.whl", hash = "sha256:d56cdaeb2d113fb66ed0fe4fb7af1da889926b0b9872032be24e19bbb09c9f5b", size = 29548, upload-time = "2025-09-28T21:50:49.373Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds re-use functionality with the [include-markdown plugin](https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/aa17cc06/README.md#mkdocs-include-markdown-plugin).

To include content from another repository, use the following syntax:

```
{%
   include-markdown "https://raw.githubusercontent.com/org/repo/branch/path/to/file.md"
%}
```