### PR TITLE
chore: upgrading broken links into errors

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -63,6 +63,7 @@ plugins:
       - "https://docs.agntcy.org/*"
       - "https://www.npmjs.com/"
       - "https://httpbin.org/"
+      - "https://console.ory.sh/"
       
       # Auto-generated anchors from API documentation
       - "#agntcy*"       # Covers all agntcy protobuf types
@@ -76,7 +77,7 @@ plugins:
       # Cross-file API references (both source and build formats)
       - "dir-*-v1-api.md#*"    # Source format
       - "../dir-*-v1-api/#*"   # Build format
-    raise_error: false
+    raise_error: true
     raise_error_after_finish: false
     validate_external_urls: true
   include-markdown:


### PR DESCRIPTION
Fixes #303 

This PR updates the linting so instead of warning, broken links in the docs return errors instead.