### PR TITLE
fix: adding link checking exemption

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -64,6 +64,7 @@ plugins:
       - "https://www.npmjs.com/"
       - "https://httpbin.org/"
       - "https://console.ory.sh/"
+      - "https://spiffe.io/"
       
       # Auto-generated anchors from API documentation
       - "#agntcy*"       # Covers all agntcy protobuf types


### PR DESCRIPTION
Adding an exemption for a url that returns 504 error during the build.