### PR TITLE
chore: update slimctl usage description and examples with the changed…

### DIFF
--- a/docs/messaging/slim-controller.md
+++ b/docs/messaging/slim-controller.md
@@ -279,6 +279,8 @@ For more information, see the [slimctl](#slimctl).
 
 `slimctl` is the command-line interface for the SLIM controller.
 
+The command line tool communicates either with the `controller` (using "controller" or "c" subcommand) or directly with the SLIM node (using the "node" or "n" subcommand)
+
 ### Configuring slimctl
 
 `slimctl` supports configuration through a configuration file, environment variables, or command-line flags.
@@ -303,23 +305,23 @@ The `server` endpoint should point to a [SLIM Control](https://github.com/agntcy
 
 List nodes:
 
-`slimctl node list`
+`slimctl controller node list`
 
 List connections on a SLIM instance:
 
-`slimctl connection list --node-id=<slim_node_id>`
+`slimctl controller connection list --node-id=<slim_node_id>`
 
 List routes on a SLIM instance:
 
-`slimctl route list --node-id=<slim_node_id>`
+`slimctl controller route list --node-id=<slim_node_id>`
 
 Add a route to the SLIM instance:
 
-`slimctl route add <organization/namespace/agentName/agentId> via <slim-node-id or path_to_config_file> --node-id=<slim_node_id>`
+`slimctl controller route add <organization/namespace/agentName/agentId> via <slim-node-id or path_to_config_file> --node-id=<slim_node_id>`
 
 Delete a route from the SLIM instance:
 
-`slimctl route del <organization/namespace/agentName/agentId> via <slim-node-id or path_to_config_file> --node-id=<slim_node_id>`
+`slimctl controller route del <organization/namespace/agentName/agentId> via <slim-node-id or path_to_config_file> --node-id=<slim_node_id>`
 
 Print version information:
 
@@ -331,7 +333,7 @@ Run `slimctl <command> --help` for more details on flags and usage.
 
 Add route for node `slim/a` to forward messages for `org/default/alice/0` to node `slim/b`.
 ```bash
-slimctl node list
+slimctl controller node list
 
 Node ID: slim/b status: CONNECTED
   Connection details:
@@ -344,11 +346,11 @@ Node ID: slim/a status: CONNECTED
     MtlsRequired: false
     ExternalEndpoint: test-slim.default.svc.cluster.local:46357
 
-slimctl route add org/default/alice/0 via slim/b --node-id slim/a
+slimctl controller route add org/default/alice/0 via slim/b --node-id slim/a
 
 
 # Delete an existing route
-slimctl route del org/default/alice/0 via slim/b --node-id slim/a
+slimctl controller route del org/default/alice/0 via slim/b --node-id slim/a
 ```
 
 ### Example 2: Create, Delete Route using `connection_config.json`
@@ -361,18 +363,18 @@ cat > connection_config.json <<EOF
 "endpoint": "http://127.0.0.1:46357"
 }
 EOF
-slimctl route add org/default/alice/0 via connection_config.json
+slimctl controller route add org/default/alice/0 via connection_config.json
 
 
 # Delete an existing route
-slimctl route del org/default/alice/0 via http://localhost:46367
+slimctl controller route del org/default/alice/0 via http://localhost:46367
 ```
 
 For full reference of connection_config.json, see the [client-config-schema.json](https://github.com/agntcy/slim/blob/slim-v0.6.0/data-plane/core/config/src/grpc/schema/client-config.schema.json).
 
 ### Managing SLIM Nodes Directly
 
-SLIM nodes can be configured to expose a Controller endpoint of a SLIM instance, slimctl can connect to this endpoint to manage the SLIM instance directly by using slimctl `node-connect` sub-command. In this case, in the configuration file, the server should point to the SLIM instance endpoint.
+SLIM nodes can be configured to expose a Controller endpoint of a SLIM instance, slimctl can connect to this endpoint to manage the SLIM instance directly by using slimctl `node` sub-command. In this case, in the configuration file, the server should point to the SLIM instance endpoint.
 
 To enable this, configure the node to host a server allowing the client to connect:
 
@@ -401,13 +403,13 @@ To enable this, configure the node to host a server allowing the client to conne
 ```
 
 List connections on a SLIM instance:
-`slimctl node-connect connection list --server=<node_control_endpoint>`
+`slimctl node connection list --server=<node_control_endpoint>`
 
 List routes on a SLIM instance:
-`slimctl node-connect route list --server=<node_control_endpoint>`
+`slimctl node route list --server=<node_control_endpoint>`
 
 Add a route to the SLIM instance:
-`slimctl node-connect route add <organization/namespace/agentName/agentId> via <config_file> --server=<node_control_endpoint>`
+`slimctl node route add <organization/namespace/agentName/agentId> via <config_file> --server=<node_control_endpoint>`
 
 Delete a route from the SLIM instance:
-`slimctl node-connect route del <organization/namespace/agentName/agentId> via <host:port> --server=<node_control_endpoint>`
+`slimctl node route del <organization/namespace/agentName/agentId> via <host:port> --server=<node_control_endpoint>`

--- a/docs/messaging/slim-group-tutorial.md
+++ b/docs/messaging/slim-group-tutorial.md
@@ -758,7 +758,7 @@ moderator of the channel, similar to the Python bindings example. However, you d
 need to handle this explicitly in the code. Run the following command to create the channel:
 
 ```bash
-./slimctl channel create moderators=agntcy/ns/client-1/9494657801285491688
+./slimctl controller channel create moderators=agntcy/ns/client-1/9494657801285491688
 ```
 
 The full name of the application can be taken from the output in the console. The value
@@ -787,8 +787,8 @@ Send a message to the group, or type 'exit' or 'quit' to quit.
 Now that the new group is created, add the additional participants `client-2` and `client-3` using the following `slimctl` commands:
 
 ```bash
-./slimctl participant add -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-2
-./slimctl participant add -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-3
+./slimctl controller participant add -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-2
+./slimctl controller participant add -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-3
 ```
 
 The expected `slimctl` output is:
@@ -813,7 +813,7 @@ At this point, every member can send messages, and they will be received by all 
 To remove one of the participants from the channel, run the following command:
 
 ```bash
-./slimctl participant delete -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-3
+./slimctl c participant delete -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-3
 ```
 
 The `slimctl` expected output is this:
@@ -833,7 +833,7 @@ equivalent to deleting the channel itself.
 To delete the channel, run the following command:
 
 ```bash
-./slimctl channel delete agntcy/ns/xyIGhc2igNGmkeBDlZ
+./slimctl controller channel delete agntcy/ns/xyIGhc2igNGmkeBDlZ
 ```
 
 The `slimctl` output is this:

--- a/docs/messaging/slim-group.md
+++ b/docs/messaging/slim-group.md
@@ -127,7 +127,7 @@ performed in the application.
 To create the group, run:
 
 ```bash
-./slimctl channel create moderators=agntcy/ns/client-1/9494657801285491688
+./slimctl controller channel create moderators=agntcy/ns/client-1/9494657801285491688
 ```
 
 The outcome should be something similar to this:
@@ -145,7 +145,7 @@ Now that the channel is created, you can start to invite new participants. To do
 the following command:
 
 ```bash
-./slimctl participant add -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-2
+./slimctl controller participant add -c agntcy/ns/xyIGhc2igNGmkeBDlZ agntcy/ns/client-2
 ```
 
 The reply to the command should be similar to this:


### PR DESCRIPTION
… behaviour

The `slimctl` command line tool has been change so that dedicated subcommands make clear the target API the tool talks to.

Usage references in the documentation have been updated with the usage related changes