### PR TITLE
feat: add redirect plugin and first config of known moved content

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,6 +17,28 @@ All pull requests should solve an existing issue. Make sure to add the issue num
 
 To submit a new pull request, fork the repository. Create a new branch for your feature or fix. Make your changes then submit a pull request.
 
+## Moving or Renaming Documentation Files
+
+If you move or rename a documentation file, **you must add a redirect** to preserve existing links. This ensures that bookmarks, external links, and search engine results continue to work.
+
+To add a redirect:
+
+1. Open `mkdocs/mkdocs.yml`
+1. Add an entry to the `redirect_maps` under the `redirects` plugin:
+
+    ```yaml
+    plugins:
+      - redirects:
+          redirect_maps:
+            'old/path/to/file.md': 'new/path/to/file.md'
+    ```
+
+1. Test the redirect locally by running `task build` or `task run` and verifying the old URL redirects to the new location
+
+!!! warning
+
+    Failing to add redirects will result in broken links and a poor user experience. Always add redirects when moving content.
+
 ## Markdown and Writing Style
 
 Generic markdown intro (if needed):

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -32,6 +32,10 @@ hooks:
 
 plugins:
   search:
+  redirects:
+    redirect_maps:
+      'how-to-guides/identity-quickstart/index.md': 'identity/identity-quickstart.md'
+      'how-to-guides/agent-directory/index.md': 'dir/getting-started.md'
   awesome-pages:
     filename: ".index"
     collapse_single_pages: true

--- a/mkdocs/pyproject.toml
+++ b/mkdocs/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "beautifulsoup4>=4.13.3",
     "mkdocs-swagger-ui-tag==0.7.1",
     "mkdocs-include-markdown-plugin>=7.2.0",
+    "mkdocs-redirects>=1.2.0",
     # Linting and testing tools
     "codespell>=2.2.0",
     "pymarkdownlnt>=0.9.0",

--- a/mkdocs/uv.lock
+++ b/mkdocs/uv.lock
@@ -54,6 +54,7 @@ dependencies = [
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocs-material-extensions" },
+    { name = "mkdocs-redirects" },
     { name = "mkdocs-swagger-ui-tag" },
     { name = "mkdocstrings-python" },
     { name = "pygments" },
@@ -80,6 +81,7 @@ requires-dist = [
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.2.0" },
     { name = "mkdocs-material", specifier = "==9.6.12" },
     { name = "mkdocs-material-extensions", specifier = ">=1.0.3" },
+    { name = "mkdocs-redirects", specifier = ">=1.2.0" },
     { name = "mkdocs-swagger-ui-tag", specifier = "==0.7.1" },
     { name = "mkdocstrings-python", specifier = "==1.16.10" },
     { name = "pygments", specifier = ">=2.12" },
@@ -1912,6 +1914,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-redirects"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a8/6d44a6cf07e969c7420cb36ab287b0669da636a2044de38a7d2208d5a758/mkdocs_redirects-1.2.2.tar.gz", hash = "sha256:3094981b42ffab29313c2c1b8ac3969861109f58b2dd58c45fc81cd44bfa0095", size = 7162, upload-time = "2024-11-07T14:57:21.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ec/38443b1f2a3821bbcb24e46cd8ba979154417794d54baf949fefde1c2146/mkdocs_redirects-1.2.2-py3-none-any.whl", hash = "sha256:7dbfa5647b79a3589da4401403d69494bd1f4ad03b9c15136720367e1f340ed5", size = 6142, upload-time = "2024-11-07T14:57:19.143Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #310 

## Add mkdocs-redirects plugin and contribution guidelines

### Changes

- **Added mkdocs-redirects plugin**: Installed and configured `mkdocs-redirects>=1.2.0` to handle URL redirects for moved documentation pages
- **Configured redirects**: Added redirect mappings for three moved pages:
  - `how-to-guides/identity-quickstart/` → `identity/identity-quickstart/`
  - `how-to-guides/agent-directory/` → `dir/getting-started/`
- **Updated contributing guide**: Added a new section on moving/renaming documentation files that requires contributors to add redirects when moving content

### Why

This ensures that external links, bookmarks, and search engine results continue to work when documentation is reorganized, providing a better user experience and maintaining SEO value.

### Testing

- Docs build successfully with `task build`
- Redirect HTML pages generated correctly in build output
- Both redirects tested and working