### PR TITLE
feat(docs): add google analytics and cookie consent

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -8,7 +8,22 @@ repo_url: https://github.com/agntcy/docs
 edit_uri: edit/main/docs/
 
 extra:
-  copyright: "© Copyright AGNTCY Contributors."
+  copyright: >
+    © Copyright AGNTCY Contributors.
+    <a href="#__consent">Change cookie settings</a>
+  analytics:
+    provider: google
+    property: G-H5NVFB80VS
+  consent:
+    title: Cookie consent
+    description: >-
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our documentation better.
+    actions:
+      - accept
+      - reject
 extra_css:
   - stylesheets/custom.css
 


### PR DESCRIPTION
This PR adds Google Analytics tracking with GDPR compliant cookie consent banner to the documentation site.