### PR TITLE
docs(dir): enhance directory CLI documentation with authentication and import options

### DIFF
--- a/docs/dir/directory-cli.md
+++ b/docs/dir/directory-cli.md
@@ -1216,4 +1216,4 @@ Use the following commands to get help with the CLI:
     dirctl routing search --help
     ```
 
-For more advanced usage, troubleshooting, and development workflows, see the [AGNTCY documentation](https://docs.agntcy.org/dir/).
+For more advanced usage, troubleshooting, and development workflows, see the [AGNTCY documentation](https://docs.agntcy.org/dir/overview/).

--- a/lychee.toml
+++ b/lychee.toml
@@ -38,6 +38,7 @@ exclude = [
     'otel-collector',
     'slim\.slim',
     'schema\.oasf\.agntcy\.org',
+    'schema\.oasf\.outshift\.com',
     'api\.agent-identity\.outshift\.com',
     'token\.actions\.githubusercontent\.com',
     'github\.com/example/',
@@ -49,6 +50,18 @@ exclude = [
 
     # GitHub Actions Artifacts (may expire or require login)
     'https://github\.com/agntcy/dir/actions/runs/.*',
+
+    # GitHub pages that redirect or require auth in CI
+    'https://github\.com/settings/developers',
+    'https://github\.com/login/device',
+    'https://github\.com/.*/edit/',
+
+    # MCP Registry (API docs; hash routes or bot blocking in CI)
+    'https://registry\.modelcontextprotocol\.io',
+
+    # Sigstore endpoints (may rate-limit or vary in CI)
+    'fulcio\.sigstore\.dev',
+    'rekor\.sigstore\.dev',
 
     # Video file path (structure differs in build vs source)
     '.*assets/dir-gui\.mov',


### PR DESCRIPTION
Makes `docs/dir/directory-cli.md` the single source of truth by merging in content from the dir repo’s `cli/README.md`.

- Merged Authentication (Device Flow, auth login/status/logout, other modes).
- Documented GitHub Device Flow; removed OAuth App prerequisites.
- Merged Import: extra flags, MCP filters, LLM enrichment, mcphost setup, signing and rate limiting.
- Added `dirctl validate` and Import / Event Streaming workflows; cross-links between Command Reference and Common Workflows.