### PR TITLE
fix: codeblock rendering

### DIFF
--- a/mkdocs/hooks.py
+++ b/mkdocs/hooks.py
@@ -2,6 +2,30 @@
 import ssl
 import certifi
 
+_STOCK_FENCED_CODE = frozenset(("fenced_code", "markdown.extensions.fenced_code"))
+
+
+def on_config(config, **kwargs):
+    """Drop stock fenced_code; pymdownx.superfences replaces it (see pymdown-extensions docs)."""
+    extensions = config.get("markdown_extensions")
+    if not extensions:
+        return config
+
+    filtered = []
+    for item in extensions:
+        if isinstance(item, str):
+            if item in _STOCK_FENCED_CODE:
+                continue
+        elif isinstance(item, dict) and len(item) == 1:
+            name = next(iter(item.keys()))
+            if name in _STOCK_FENCED_CODE:
+                continue
+        filtered.append(item)
+
+    config["markdown_extensions"] = filtered
+    return config
+
+
 # Monkey patch urllib to use certifi's certificate bundle
 def on_startup(**kwargs):
     """Configure SSL context to use certifi certificates."""

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -33,17 +33,17 @@ markdown_extensions:
   - def_list
   - md_in_html
   - pymdownx.details
-  - pymdownx.superfences
-  - pymdownx.tabbed:
-      alternate_style: true
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 hooks:
   - hooks.py

--- a/mkdocs/pyproject.toml
+++ b/mkdocs/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "mkdocs-material-extensions>=1.0.3",
     "mkdocs-autorefs==1.4.1",
     "pygments>=2.20.0",
-    "pymdown-extensions>=9.4",
+    "pymdown-extensions>=10.21.2",
     "mkdocs-git-revision-date-plugin==0.3.2",
     "mkdocstrings-python==1.16.10",
     "griffe-pydantic==1.1.4",

--- a/mkdocs/uv.lock
+++ b/mkdocs/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12.4' and python_full_version < '4'",
@@ -96,7 +96,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pymarkdownlnt", specifier = ">=0.9.0" },
-    { name = "pymdown-extensions", specifier = ">=9.4" },
+    { name = "pymdown-extensions", specifier = ">=10.21.2" },
 ]
 
 [[package]]
@@ -2809,15 +2809,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.16.1"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
fixes #465 


- upgrades `pymdown-extensions` for Pygments 2.20 compatibility
- enables `pymdownx.highlight` with a single SuperFences + Mermaid config
- drops the stock `fenced_code` extension

<img width="2658" height="1850" alt="image" src="https://github.com/user-attachments/assets/dfdeda9b-9c8d-4807-93f9-f1a31710f085" />
