### PR TITLE
docs(dir): add export operations to CLI reference

### DIFF
--- a/docs/dir/directory-cli-reference.md
+++ b/docs/dir/directory-cli-reference.md
@@ -463,6 +463,76 @@ dirctl import --type=mcp \
   --enrich-rate-limit=30
 ```
 
+## Export Operations
+
+Export records from the Directory into formats consumable by external tools and agentic CLIs. Supports single-record export by CID/name and batch export from search results.
+
+### `dirctl export <cid-or-name[:version][@digest]> [flags]`
+
+Pull a record and transform it to the requested format.
+
+**Supported Formats:**
+
+| Format | Output | Description |
+|--------|--------|-------------|
+| `oasf` | `.json` | Raw OASF record JSON (default) |
+| `a2a` | `.json` | A2A AgentCard JSON for Agent-to-Agent protocol interop |
+| `agent-skill` | `.md` | SKILL.md artifact for agentic CLI consumption (Cursor, Claude Code, etc.) |
+| `mcp-ghcopilot` | `.json` | GitHub Copilot MCP configuration JSON |
+
+**Single-record Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--format` | Export format (see table above) | `oasf` |
+| `--output-file` | File path to write the exported data (default: stdout) | - |
+
+**Batch Export Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--output-dir` | Directory for batch export from search results | - |
+| `--all-versions` | Keep all versions (default: only latest semver per name) | `false` |
+| `--limit` | Maximum number of records to export | `100` |
+
+When `--output-dir` is used, at least one search filter is required. All standard search filters are available (`--name`, `--version`, `--module`, `--skill`, `--author`, etc.).
+
+!!! note "Batch behaviour varies by format"
+
+    - **a2a / oasf**: One file per record (`<name>.json`).
+    - **agent-skill**: One subdirectory per skill (`<name>/SKILL.md`).
+    - **mcp-ghcopilot**: All matched MCP servers are merged into a single `mcp.json` with combined `servers` and `inputs` maps.
+
+??? example
+
+    ```bash
+    # Export a single record as A2A AgentCard to stdout
+    dirctl export baeareihdr6t7s6... --format=a2a
+
+    # Export to a file (auto-appends extension if omitted)
+    dirctl export my-agent:1.0 --format=a2a --output-file=./agent-card.json
+    dirctl export my-agent:1.0 --format=agent-skill --output-file=./SKILL.md
+
+    # Batch export A2A records to a directory
+    dirctl export --output-dir=./exports/ --format=a2a --module "integration/a2a"
+
+    # Batch export skills (creates subdirectories with SKILL.md)
+    dirctl export --output-dir=./exports/ --format=agent-skill \
+      --module "core/language_model/agentskills"
+
+    # Batch export MCP servers (merged into a single config)
+    dirctl export --output-dir=./exports/ --format=mcp-ghcopilot \
+      --module "integration/mcp"
+
+    # Export all versions instead of only the latest
+    dirctl export --output-dir=./exports/ --format=a2a \
+      --name "my-agent" --all-versions
+
+    # Combine multiple search filters
+    dirctl export --output-dir=./exports/ --format=a2a \
+      --author "acme" --skill "natural_language_processing"
+    ```
+
 ## Routing Operations
 
 The routing commands manage record announcement and discovery across the peer-to-peer network.

--- a/docs/dir/directory-cli-reference.md
+++ b/docs/dir/directory-cli-reference.md
@@ -499,6 +499,8 @@ When `--output-dir` is used, at least one search filter is required. All standar
 
 !!! note "Batch behaviour varies by format"
 
+    For different export formats, the batch behaviour varies:
+
     - **a2a / oasf**: One file per record (`<name>.json`).
     - **agent-skill**: One subdirectory per skill (`<name>/SKILL.md`).
     - **mcp-ghcopilot**: All matched MCP servers are merged into a single `mcp.json` with combined `servers` and `inputs` maps.

--- a/docs/dir/directory-cli.md
+++ b/docs/dir/directory-cli.md
@@ -252,6 +252,39 @@ dirctl import --type=mcp \
 dirctl search --query "module=runtime/mcp"
 ```
 
+### Export Workflow
+
+Export records from the Directory into formats consumable by external tools and agentic CLIs:
+
+```bash
+# 1. Export a single record as an A2A AgentCard
+dirctl export my-agent:1.0 --format=a2a --output-file=./agent-card.json
+
+# 2. Export a single record as a SKILL.md for Cursor, Claude Code, etc.
+dirctl export my-agent:1.0 --format=agent-skill --output-file=./SKILL.md
+
+# 3. Export a single record as a GitHub Copilot MCP config
+dirctl export my-agent:1.0 --format=mcp-ghcopilot --output-file=./mcp.json
+```
+
+Batch export uses `--output-dir` with search filters to export multiple records at once. Each format handles batch output differently:
+
+```bash
+# Batch export A2A records — one JSON file per record
+dirctl export --output-dir=./exports/ --format=a2a --module "integration/a2a"
+# Result: ./exports/my-agent.json, ./exports/other-agent.json, ...
+
+# Batch export skills — one subdirectory per skill with SKILL.md
+dirctl export --output-dir=./exports/ --format=agent-skill --module "core/language_model/agentskills"
+# Result: ./exports/code-review/SKILL.md, ./exports/testing/SKILL.md, ...
+
+# Batch export MCP servers — all merged into a single config file
+dirctl export --output-dir=./exports/ --format=mcp-ghcopilot --module "integration/mcp"
+# Result: ./exports/mcp.json (contains all matched servers)
+```
+
+By default, when multiple versions of the same record exist, only the latest semver version is exported. Use `--all-versions` to export every version (the version is appended to the filename to avoid collisions).
+
 ### Event Streaming Workflow
 
 Listen to directory events and process them (e.g. filter by type or labels):
@@ -474,6 +507,7 @@ The CLI follows a clear service-based organization:
 - **Auth**: GitHub OAuth authentication (`auth login`, `auth logout`, `auth status`).
 - **Storage**: Direct record management (`push`, `pull`, `delete`, `info`).
 - **Import**: Batch imports from external registries (`import`).
+- **Export**: Export records to external formats (`export`).
 - **Routing**: Network announcement and discovery (`routing publish`, `routing list`, `routing search`).
 - **Search**: General content search (`search`).
 - **Security**: Signing, verification, and validation (`sign`, `verify`, `validate`, `naming verify`).

--- a/docs/dir/directory-cli.md
+++ b/docs/dir/directory-cli.md
@@ -283,7 +283,8 @@ dirctl export --output-dir=./exports/ --format=mcp-ghcopilot --module "integrati
 # Result: ./exports/mcp.json (contains all matched servers)
 ```
 
-By default, when multiple versions of the same record exist, only the latest semver version is exported. Use `--all-versions` to export every version (the version is appended to the filename to avoid collisions).
+!!! note
+    By default, when multiple versions of the same record exist, only the latest semver version is exported. Use `--all-versions` to export every version (the version is appended to the filename to avoid collisions).
 
 ### Event Streaming Workflow
 


### PR DESCRIPTION
https://github.com/agntcy/dir/issues/1336

Document the new `dirctl export` command, which transforms Directory records into formats consumable by external tools and agentic CLIs.

Export feature will only be released in v1.3.0. @keraron, what are your thoughts on merging documentation for not yet released features?