### PR TITLE
ci: use official taskfile action

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,17 +19,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.1'
+          go-version: "1.23.1"
 
       - name: Setup Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
-          version: '3.48.0'
+          version: "3.48.0"
 
       - name: Setup UV
         shell: bash
@@ -47,8 +47,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2.0.2  # CVE-2024-48908: pin >=2.0.2
+        uses: lycheeverse/lychee-action@v2.0.2 # CVE-2024-48908: pin >=2.0.2
         with:
           args: '--config lychee.toml --exclude-path "(^|/)404\\.html$" .build/site'
           fail: true
-

--- a/.github/workflows/pr-links.yml
+++ b/.github/workflows/pr-links.yml
@@ -20,24 +20,24 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Clone repository (manual)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.1'
+          go-version: "1.23.1"
 
       - name: Setup Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v2
         with:
-          version: '3.48.0'
+          version: "3.48.0"
 
       - name: Setup UV
         shell: bash
@@ -93,9 +93,9 @@ jobs:
 
       - name: Check links
         if: steps.get_paths.outputs.has_paths == 'true'
-        uses: lycheeverse/lychee-action@v2.0.2  # CVE-2024-48908: pin >=2.0.2
+        uses: lycheeverse/lychee-action@v2.0.2 # CVE-2024-48908: pin >=2.0.2
         with:
-          lycheeVersion: "v0.22.0"  # v0.16.x (action default) does not support --root-dir; added in v0.18
+          lycheeVersion: "v0.22.0" # v0.16.x (action default) does not support --root-dir; added in v0.18
           args: |
             --no-progress
             --config lychee.toml

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -7,12 +7,12 @@ on:
   workflow_call:
     inputs:
       deploy:
-        description: 'Deploy documentation artifacts'
+        description: "Deploy documentation artifacts"
         required: true
         type: boolean
         default: false
       version:
-        description: 'Version to use for documentation artifacts'
+        description: "Version to use for documentation artifacts"
         required: true
         type: string
         default: dev
@@ -20,12 +20,12 @@ on:
   workflow_dispatch:
     inputs:
       deploy:
-        description: 'Deploy documentation artifacts'
+        description: "Deploy documentation artifacts"
         required: true
         type: boolean
         default: false
       version:
-        description: 'Version to use for documentation artifacts'
+        description: "Version to use for documentation artifacts"
         required: true
         type: string
         default: dev
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Setup Pages
         id: pages
@@ -53,12 +53,12 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.1'
+          go-version: "1.23.1"
 
-      - name: Setup Taskfile
-        shell: bash
-        run: |
-          sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Setup Task
+        uses: go-task/setup-task@v2
+        with:
+          version: "3.48.0"
 
       - name: Setup UV
         shell: bash


### PR DESCRIPTION
Taskfile now have official action which provides better caching and versioning:
https://taskfile.dev/docs/installation#github-actions